### PR TITLE
Added extra variable to loop to not run strlen on each iteration

### DIFF
--- a/transmitter/transmitter.ino
+++ b/transmitter/transmitter.ino
@@ -25,7 +25,7 @@ void setup() {
   lcd.setCursor(0, 0);
   lcd.print(message);
 
-  for (int byte_idx = 0; byte_idx < strlen(message); byte_idx++) {
+  for (int byte_idx = 0, msg_len = strlen(message); byte_idx < msg_len; byte_idx++) {
     char tx_byte = message[byte_idx];
 
     // Clear the second line of the display


### PR DESCRIPTION
The `strlen` in the condition of the for-loop in the `setup()` function is run on every iteration. As always when dealing with strings, it can be slow. Therefore, I'd suggest running the `strlen` once and storing the result somewhere. This will lead to the same result, but faster.